### PR TITLE
Update rules_fuzzing dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,6 +9,19 @@ workspace_dependencies()
 
 register_toolchains("//toolchains/cc:all")
 
+## Fuzzing dependencies.
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+
+rules_fuzzing_dependencies()
+
+load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
+
+rules_fuzzing_init()
+
+load("@fuzzing_py_deps//:requirements.bzl", "install_deps")
+
+install_deps()
+
 ## Go dependencies & toolchain.
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
@@ -311,15 +324,6 @@ crate_repositories()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
-
-## Fuzzing dependencies.
-load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
-
-rules_fuzzing_dependencies()
-
-load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
-
-rules_fuzzing_init()
 
 ## C/C++ dependencies (foreign toolchains).
 

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -99,9 +99,9 @@ def workspace_dependencies():
 
     http_archive(
         name = "rules_fuzzing",
-        version = "0.3.2",
-        sha256 = "d9002dd3cd6437017f08593124fdd1b13b3473c7b929ceb0e60d317cb9346118",
-        urls = ["https://github.com/bazelbuild/{name}/archive/v{version}.zip"],
+        version = "9865504b549e86ccfb4713afcc1914c982567f05", # > 0.3.2
+        sha256 = "e711a5169ec5f295893328d859b71778614d31760c6942165b4b3131515c5a25",
+        urls = ["https://github.com/bazelbuild/{name}/archive/{version}.zip"],
         strip_prefix = "{name}-{version}",
         build_file_content = None,
     )


### PR DESCRIPTION
This is required to fix an issue introduced when upgrading to Ubuntu 22.04.