### PR TITLE
Add a Nix shell wrapper.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.libcxxStdenv
+  ];
+}

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+nix-shell --run "${SHELL}"


### PR DESCRIPTION
This helps when running in a minimal environment where packages are provided using `nixpkgs` and/or home-manager.